### PR TITLE
Add phpenv CLI with installer and smart php8x shims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/shims/
+/.idea/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,53 @@
 # PHP Images
 
+Ready-to-use docker images for PHP 8.1–8.5 (`ghcr.io/patchlevel/php`) plus a
+small `phpenv` helper that gives you `php81` … `php85` commands on your `$PATH`.
+
+## Install
+
 ```bash
-alias php80='docker run --rm -it --volume $PWD:/app -w /app ghcr.io/patchlevel/php:8.0'
-alias php81='docker run --rm -it --volume $PWD:/app -w /app ghcr.io/patchlevel/php:8.1'
-alias php82='docker run --rm -it --volume $PWD:/app -w /app ghcr.io/patchlevel/php:8.2'
-alias php83='docker run --rm -it --volume $PWD:/app -w /app ghcr.io/patchlevel/php:8.3'
-alias php84='docker run --rm -it --volume $PWD:/app -w /app ghcr.io/patchlevel/php:8.4'
-alias php85='docker run --rm -it --volume $PWD:/app -w /app ghcr.io/patchlevel/php:8.5'
+curl -fsSL https://raw.githubusercontent.com/patchlevel/php/main/install.sh | bash
+```
+
+The installer generates the `php8x` commands, adds them to your `$PATH`
+(`~/.zshrc` / `~/.bashrc`) and makes the `phpenv` command available.
+
+Restart your shell (or `source` your rc file), then pull the images:
+
+```bash
+phpenv pull
+```
+
+## Usage
+
+Each version is available as its own command and runs in the current directory.
+The command is smart about its arguments:
+
+```bash
+php85                 # no args  -> interactive PHP REPL (php -a)
+php85 -v             # a flag   -> runs php with it (php -v)
+php85 -r 'echo 1;'   #          -> php -r '...'
+php85 composer install   # a word -> runs that command in the container
+php85 vendor/bin/phpunit
+php85 bash               # drop into a shell inside the container
+```
+
+Rule of thumb: if the first argument starts with `-` it is passed to `php`,
+otherwise it is executed as a command inside the container.
+
+It also works in pipes and CI — when no terminal is attached the docker
+container is started without an interactive TTY:
+
+```bash
+echo '<?php echo PHP_VERSION;' | php85 php
+```
+
+## Managing phpenv
+
+```bash
+phpenv list        # show available versions and their commands
+phpenv pull        # pull all docker images
+phpenv update      # git pull, regenerate the commands and pull images
+phpenv uninstall   # remove the commands and the PATH entry
+phpenv help        # show all commands
 ```

--- a/bin/phpenv
+++ b/bin/phpenv
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the directory of this script, following symlinks, so PHPENV_ROOT
+# always points at the cloned repository regardless of how phpenv was called.
+resolve_root() {
+  local src="${BASH_SOURCE[0]}"
+  while [ -h "$src" ]; do
+    local dir
+    dir="$(cd -P "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    [[ $src != /* ]] && src="$dir/$src"
+  done
+  cd -P "$(dirname "$src")/.." && pwd
+}
+
+PHPENV_ROOT="$(resolve_root)"
+SHIM_DIR="$PHPENV_ROOT/shims"
+
+# Configuration (overridable via environment).
+PHPENV_IMAGE="${PHPENV_IMAGE:-ghcr.io/patchlevel/php}"
+PHPENV_VERSIONS=(8.1 8.2 8.3 8.4 8.5)
+
+BEGIN_MARK="# >>> phpenv >>>"
+END_MARK="# <<< phpenv <<<"
+
+# --- helpers ---------------------------------------------------------------
+
+shim_name() {
+  # 8.5 -> php85
+  echo "php${1//./}"
+}
+
+profile_file() {
+  case "$(basename "${SHELL:-}")" in
+    zsh)  echo "$HOME/.zshrc" ;;
+    bash) if [ -f "$HOME/.bashrc" ]; then echo "$HOME/.bashrc"; else echo "$HOME/.bash_profile"; fi ;;
+    *)    echo "$HOME/.profile" ;;
+  esac
+}
+
+remove_block() {
+  local rc="$1"
+  [ -f "$rc" ] || return 0
+  awk -v b="$BEGIN_MARK" -v e="$END_MARK" '
+    $0==b {skip=1; next}
+    $0==e {skip=0; next}
+    !skip {print}
+  ' "$rc" > "$rc.phpenv.tmp" && mv "$rc.phpenv.tmp" "$rc"
+}
+
+generate_shims() {
+  mkdir -p "$SHIM_DIR"
+  local v name file
+  for v in "${PHPENV_VERSIONS[@]}"; do
+    name="$(shim_name "$v")"
+    file="$SHIM_DIR/$name"
+    cat > "$file" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="$PHPENV_IMAGE:$v"
+
+# Only allocate an interactive TTY when we actually have one. This keeps the
+# command usable in pipes and CI (e.g. \`echo '<?php ...' | $name\`).
+flags=(--rm)
+if [ -t 0 ] && [ -t 1 ]; then
+  flags+=(-it)
+fi
+
+# Smart dispatch:
+#   - no arguments        -> the image default (php -a, an interactive REPL)
+#   - first arg is a flag -> run php with it ($name -v  -> php -v)
+#   - first arg is a word -> run it as a command ($name composer install, $name bash)
+if [ "\$#" -gt 0 ] && [ "\${1#-}" != "\$1" ]; then
+  set -- php "\$@"
+fi
+
+exec docker run "\${flags[@]}" --volume "\$PWD:/app" -w /app "\$IMAGE" "\$@"
+EOF
+    chmod +x "$file"
+  done
+}
+
+add_path() {
+  local rc
+  rc="$(profile_file)"
+  remove_block "$rc"
+  {
+    echo "$BEGIN_MARK"
+    echo "export PATH=\"$SHIM_DIR:$PHPENV_ROOT/bin:\$PATH\""
+    echo "$END_MARK"
+  } >> "$rc"
+  echo "$rc"
+}
+
+# --- commands --------------------------------------------------------------
+
+cmd_install() {
+  generate_shims
+  local rc
+  rc="$(add_path)"
+  echo "phpenv installed."
+  echo
+  echo "  Repository : $PHPENV_ROOT"
+  echo "  Shims      : $SHIM_DIR"
+  echo "  PATH added : $rc"
+  echo
+  echo "Available commands: $(for v in "${PHPENV_VERSIONS[@]}"; do printf '%s ' "$(shim_name "$v")"; done)"
+  echo
+  echo "Restart your shell or run:  source \"$rc\""
+  echo "Then pull the images with:  phpenv pull"
+}
+
+cmd_update() {
+  if [ -d "$PHPENV_ROOT/.git" ]; then
+    echo "Updating repository ..."
+    git -C "$PHPENV_ROOT" pull --ff-only
+  fi
+  generate_shims
+  cmd_pull
+  echo "phpenv updated."
+}
+
+cmd_pull() {
+  local v
+  for v in "${PHPENV_VERSIONS[@]}"; do
+    echo "Pulling $PHPENV_IMAGE:$v ..."
+    docker pull "$PHPENV_IMAGE:$v"
+  done
+}
+
+cmd_uninstall() {
+  rm -rf "$SHIM_DIR"
+  local rc
+  rc="$(profile_file)"
+  remove_block "$rc"
+  echo "Removed shims and PATH entry from $rc."
+  echo "The repository at $PHPENV_ROOT was kept."
+  echo "Remove it too with:  rm -rf \"$PHPENV_ROOT\""
+}
+
+cmd_list() {
+  local v
+  for v in "${PHPENV_VERSIONS[@]}"; do
+    printf '  %-6s ->  %s:%s\n' "$(shim_name "$v")" "$PHPENV_IMAGE" "$v"
+  done
+}
+
+cmd_help() {
+  cat <<EOF
+phpenv - manage the patchlevel PHP docker images
+
+Usage: phpenv <command>
+
+Commands:
+  install     Generate the php* shims and add them to your PATH
+  update      Pull the latest repo changes, regenerate shims and pull images
+  pull        Pull all PHP docker images
+  list        List the available PHP versions and their commands
+  uninstall   Remove the shims and the PATH entry
+  help        Show this help
+
+After installing, use the generated commands directly, e.g.:
+  php85 -v
+  php84 vendor/bin/phpunit
+  echo '<?php echo PHP_VERSION;' | php85
+EOF
+}
+
+# --- dispatch --------------------------------------------------------------
+
+case "${1:-help}" in
+  install)            cmd_install ;;
+  update)             cmd_update ;;
+  pull)               cmd_pull ;;
+  list|versions)      cmd_list ;;
+  uninstall|remove)   cmd_uninstall ;;
+  help|-h|--help)     cmd_help ;;
+  *)
+    echo "Unknown command: $1" >&2
+    echo >&2
+    cmd_help >&2
+    exit 1
+    ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installer for phpenv.
+#
+# Works in two ways:
+#   1. Run from a local checkout:  ./install.sh
+#   2. Piped from the web:         curl -fsSL <raw-url>/install.sh | bash
+#      (clones the repo into ~/.phpenv first)
+
+REPO_URL="${PHPENV_REPO_URL:-https://github.com/patchlevel/php.git}"
+DEFAULT_ROOT="${PHPENV_ROOT:-$HOME/.phpenv}"
+
+# Figure out whether we are running from inside a checkout.
+SCRIPT_DIR=""
+if [ -n "${BASH_SOURCE[0]:-}" ] && [ -f "${BASH_SOURCE[0]}" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/bin/phpenv" ]; then
+  PHPENV_ROOT="$SCRIPT_DIR"
+else
+  PHPENV_ROOT="$DEFAULT_ROOT"
+  if [ -d "$PHPENV_ROOT/.git" ]; then
+    echo "Updating existing checkout at $PHPENV_ROOT ..."
+    git -C "$PHPENV_ROOT" pull --ff-only
+  else
+    echo "Cloning $REPO_URL into $PHPENV_ROOT ..."
+    git clone "$REPO_URL" "$PHPENV_ROOT"
+  fi
+fi
+
+exec "$PHPENV_ROOT/bin/phpenv" install


### PR DESCRIPTION
## Summary

Replaces the manual `.bashrc` aliases with a proper `phpenv` command and an install script.

## What's new

- **`install.sh`** — clones the repo (or uses an existing local checkout) and runs the installer.
- **`bin/phpenv`** — CLI with:
  - `install` — generate the `php81`…`php85` shims and add them to `$PATH`
  - `update` — git pull, regenerate shims and pull all images
  - `pull` — pull all docker images
  - `list` — show available versions and their commands
  - `uninstall` — remove shims and the PATH entry (via markers in `.zshrc`/`.bashrc`)
- **Generated shims** (`php81`…`php85`, gitignored):
  - **TTY detection** — only pass `-it` when a terminal is attached, so they work in pipes and CI.
  - **Smart dispatch** — a leading flag goes to `php` (`php85 -v` → `php -v`), any other word runs as a command in the container (`php85 composer install`, `php85 bash`), no args starts the REPL.

## Notes

- Versions are aligned to what CI builds (8.1–8.5); a single `PHPENV_VERSIONS` list in `bin/phpenv` is the source of truth.
- Fixes the long-standing issue where `php85 -v` failed with `exec -v failed` because the flag replaced the image `CMD` and tini tried to exec it.